### PR TITLE
Fix typos

### DIFF
--- a/hardware/max_storage_temp_tutorial.ipynb
+++ b/hardware/max_storage_temp_tutorial.ipynb
@@ -28,7 +28,7 @@
     "\n",
     "# Phase 1: KBC Initialization\n",
     "\n",
-    "In this first phase of `Fonduer`'s pipeline, `Fonduer` uses a user-specified _schema_ to initialize a relational database where the output KB will be stored. Furthermore, `Fonduer` iterates over its input _corpus_ and transforms each document into a unified data model, which captures the variability and multimodality of richly formatted data. This unified data model then servers as an intermediate representation used in the rest of the phases.\n",
+    "In this first phase of `Fonduer`'s pipeline, `Fonduer` uses a user-specified _schema_ to initialize a relational database where the output KB will be stored. Furthermore, `Fonduer` iterates over its input _corpus_ and transforms each document into a unified data model, which captures the variability and multimodality of richly formatted data. This unified data model then serves as an intermediate representation used in the rest of the phases.\n",
     "\n",
     "This preprocessed data is saved to a database. The connection string to the database is provided to the `Meta` object, which will initialize a PostgreSQL database for parallel execution.\n",
     "\n",


### PR DESCRIPTION
Change “This unified data model then servers as an intermediate representation used in the rest of the phases” to “This unified data model then serves as an intermediate representation used in the rest of the phases”