### PR TITLE
Fix more typos

### DIFF
--- a/hardware/max_storage_temp_tutorial.ipynb
+++ b/hardware/max_storage_temp_tutorial.ipynb
@@ -208,7 +208,7 @@
    "source": [
     "## 1.2 Dividing the Corpus into Test and Train\n",
     "\n",
-    "We'll split the documents 80/10/10 into train/dev/test splits. Note that here we do this in a non-random order to preverse the consistency in the tutorial, and we reference the splits by 0/1/2 respectively."
+    "We'll split the documents 80/10/10 into train/dev/test splits. Note that here we do this in a non-random order to preserve the consistency in the tutorial, and we reference the splits by 0/1/2 respectively."
    ]
   },
   {


### PR DESCRIPTION
Change "Note that here we do this in a non-random order to preverse the consistency in the tutorial" to "Note that here we do this in a non-random order to preserve the consistency in the tutorial"