### PR TITLE
Fix even more typos

### DIFF
--- a/hardware/max_storage_temp_tutorial.ipynb
+++ b/hardware/max_storage_temp_tutorial.ipynb
@@ -678,7 +678,7 @@
    "source": [
     "### Running the `CandidateExtractor`\n",
     "\n",
-    "Now, we have all the component necessary to perform candidate extraction. We have defined the Mentions that compose each candidate and a throttler to prunes away excess candidates. We now can define the `CandidateExtractor` with the candidate subclass and corresponding throttler to use.\n",
+    "Now, we have all the component necessary to perform candidate extraction. We have defined the Mentions that compose each candidate and a throttler to prune away excess candidates. We now can define the `CandidateExtractor` with the candidate subclass and corresponding throttler to use.\n",
     "\n",
     "View the API for the CandidateExtractor on [ReadTheDocs](https://fonduer.readthedocs.io/en/stable/user/candidates.html#fonduer.candidates.MentionExtractor)."
    ]


### PR DESCRIPTION
Change "We have defined the Mentions that compose each candidate and a throttler to prunes away excess candidates" to "We have defined the Mentions that compose each candidate and a throttler to prune away excess candidates"