### PR TITLE
Download data for hardware tutorial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,5 +30,6 @@ RUN sed -i -e 's/localhost/postgres/g' */*.ipynb
 RUN sed -i -e 's/dropdb/dropdb -h postgres/g' intro/*.ipynb
 RUN sed -i -e 's/createdb/createdb -h postgres/g' intro/*.ipynb
 RUN sed -i -e 's/psql/psql -h postgres/g' intro/*.ipynb
+RUN cd hardware && /bin/bash download_data.sh
 RUN cd hardware_image && /bin/bash download_data.sh
 RUN cd intro && /bin/bash download_data.sh


### PR DESCRIPTION
This patch is to resolve an issue that Docker image does not have data for the hardware tutorial.
This issue has not happened for the past builds, because I had downloaded data and the following line in the Dockerfile copied the data into the image.

```
COPY --chown=jovyan:users hardware hardware
```

The issue arose when I built a new image for v0.4.0 on a freshly cloned repository.