### PR TITLE
Install packages using requirements.txt as jovyan

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,15 +14,14 @@ RUN apt-get update && apt-get install -y \
  && rm -rf /var/lib/{apt,dpkg,cache,log}/
 RUN rm /etc/ImageMagick-6/policy.xml
 
-RUN pip install torch==0.4.1
-RUN pip install \
-    fonduer==0.4.0 \
-    matplotlib
+USER $NB_UID
+
+COPY requirements.txt .
+RUN pip install -r requirements.txt \
+    && rm requirements.txt
 
 RUN python -m spacy download en
 RUN conda install -y -c conda-forge ipywidgets
-
-USER $NB_UID
 
 # Copy notebooks and download data
 COPY --chown=jovyan:users hardware hardware


### PR DESCRIPTION
To reduce things to update on a version release, Dockerfile now uses the requirements.txt to install python packages.