### PR TITLE
Stop one of the duplicate matplotlib installations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,6 @@ USER root
 RUN apt-get update && apt-get install -y \
     libxml2-dev \
     libxslt-dev \
-    python-matplotlib \
     poppler-utils \
     postgresql-client \
     libmagickwand-dev \


### PR DESCRIPTION
matplotlib can be installaed in three ways: pip, apt, build from source.
(See https://matplotlib.org/users/installing.html)
The current Dockerfile does both pip and apt, which is redundant.
This patch stops the apt one.