### PR TITLE
libxml2-dev/libxslt-dev not required for lxml 3.6.3+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,6 @@ LABEL maintainer="Hiromu Hota <hiromu.hota@hal.hitachi.com>"
 USER root
 
 RUN apt-get update && apt-get install -y \
-    libxml2-dev \
-    libxslt-dev \
     poppler-utils \
     postgresql-client \
     libmagickwand-dev \


### PR DESCRIPTION
libxml2-dev/libxslt-dev are required only when lxml is compiled from source.
But binary wheels (e.g., manylinux1_x86_64) are available for lxml 3.6.3+.